### PR TITLE
DataAnnotation for Guid.Empty

### DIFF
--- a/WebApi/App_Code/NoGuidEmpty.cs
+++ b/WebApi/App_Code/NoGuidEmpty.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace WebApi
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public sealed class NoGuidEmpty : ValidationAttribute
+    {
+        public override bool IsValid(object value) => (Guid)value != Guid.Empty;
+    }
+}

--- a/WebApi/Models/Event.cs
+++ b/WebApi/Models/Event.cs
@@ -5,8 +5,8 @@ namespace WebApi.Models
 {
     public class Event
     {
-        [Required] public Guid EventId { get; set; }
-        [Required] public Guid PartnerId { get; set; }
+        [Required] [NoGuidEmpty] public Guid EventId { get; set; }
+        [Required] [NoGuidEmpty] public Guid PartnerId { get; set; }
         [Required] [StringLength(100)] public string EventName { get; set; }
         [Required] [StringLength(100)] public string AddressLine1 { get; set; }
         [Required] [StringLength(10)] public string PostalCode { get; set; }

--- a/WebApi/Models/Video.cs
+++ b/WebApi/Models/Video.cs
@@ -5,8 +5,8 @@ namespace WebApi.Models
 {
     public class Video
     {
-        [Required] public Guid VideoId { get; set; }
-        [Required] public Guid PartnerId { get; set; }
+        [Required] [NoGuidEmpty] public Guid VideoId { get; set; }
+        [Required] [NoGuidEmpty] public Guid PartnerId { get; set; }
         [Required] [StringLength(100)] public string VideoName { get; set; }
         [Required] [StringLength(50)] public string Url { get; set; }
     }

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -60,7 +60,7 @@ namespace WebApi
             }
 
             lifetime.ApplicationStarted.Register(OnApplicationStarted);
-            //lifetime.ApplicationStopping.Register(OnApplicationStopped);
+            lifetime.ApplicationStopping.Register(OnApplicationStopped);
 
             app.UseHttpsRedirection();
             app.UseMvc();
@@ -83,13 +83,13 @@ namespace WebApi
             _s3Initialiser.Init();
         }
 
-        //private void OnApplicationStopped()
-        //{
-        //    _logger.LogInformation("Tearing down database.");
-        //    _dbInitialiser.Dispose();
+        private void OnApplicationStopped()
+        {
+            _logger.LogInformation("Tearing down database.");
+            _dbInitialiser.Dispose();
 
-        //    _logger.LogInformation("Destroying s3 bucket.");
-        //    _s3Initialiser.Dispose();
-        //}
+            _logger.LogInformation("Destroying s3 bucket.");
+            _s3Initialiser.Dispose();
+        }
     }
 }


### PR DESCRIPTION
- Create custom DataAnnotation for ensuring no empty GUIDs, `Required` does not do the job.
- Bring back the teardown on application stop, it keeps the integration tests happy.